### PR TITLE
fix: play nice with watchify

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,14 @@ function rollupify(filename, opts) {
       var generated = bundle.generate({format: 'cjs'});
       self.push(generated.code);
       self.push(null);
+
+      bundle.modules.forEach(function(module) {
+        var file = module.id;
+        if (!/\.tmp$/.test(file)) {
+          self.emit('file', file)
+        }
+      });
+
       return unlink(tmpfile);
     }).then(function () {
       cb();


### PR DESCRIPTION
Currently, changes to files within the rollup bundle don't trigger a recompile in watchify.
This PR makes sure we emit file changes within the rollup bundle so that watchify picks them up.
Anybody has a nice and simple way to test this? :)

Known limitation: it doesn't pick up new files added at runtime.
